### PR TITLE
DOCS-10, set explicit value for --ifm-alert-background-color

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -36,6 +36,14 @@
   padding: 0 var(--ifm-pre-padding);
 }
 
+/**
+Docusaurus default styling sets '.alert.alert--secondary' background-color to
+--ifm-color-secondary. This sets the value explicitly. See DOCS-10.
+**/
+.alert.alert--secondary {
+  --ifm-alert-background-color: #EBEDF0;
+}
+
 @font-face {
   font-family: RbNo31;
   src: url('/font/RBNo31-Light.ttf') format('truetype');


### PR DESCRIPTION
By default Docusaurus sets --ifm-alert-background-color to the secondary color, in our case Luxor Gold #9C7C33. By setting this variable explicitly it makes notes admonitions more readable.

![image](https://user-images.githubusercontent.com/2548047/79053188-2d43b180-7bf0-11ea-92ea-e39caab6d381.png)
 