### PR TITLE
Add release notes for monitoring agent

### DIFF
--- a/docs/plugin_monitoring_agent.md
+++ b/docs/plugin_monitoring_agent.md
@@ -22,19 +22,19 @@ The 128T Monitoring Agent can be obtained from the official 128T software reposi
 
 | Monitoring Agent | 128T |
 | --- | --- |
-| 128T-monitoring-agent-1.1.0 | 128T >= 4.1.0; 128T < 4.3.0 |
-| 128T-monitoring-agent-2.0.0 | 128T >= 4.3.0 |
+| 128T-monitoring-agent-1.1.1 | 128T >= 4.1.0; 128T < 4.3.0 |
+| 128T-monitoring-agent-2.0.1 | 128T >= 4.3.0 |
 
 The agent can be install using dnf utility. For example.
 ```
 # dnf install 128T-monitoring-agent
-Last metadata expiration check: 0:04:59 ago on Wed 15 Apr 2020 06:25:48 AM UTC.
+Last metadata expiration check: 0:00:31 ago on Tue 28 Apr 2020 02:40:10 PM UTC.
 Dependencies resolved.
 ==============================================================================================================================================================================================================================================================
  Package                                                               Arch                                                   Version                                                   Repository                                                       Size
 ==============================================================================================================================================================================================================================================================
 Installing:
- 128T-monitoring-agent                                                 x86_64                                                 2.0.0-3                                                   plugins-staging                                                 5.0 M
+ 128T-monitoring-agent                                                 x86_64                                                 2.0.1-2                                                   plugins-staging                                                 5.0 M
 Installing dependencies:
  telegraf-128tech                                                      x86_64                                                 1.14.0-1                                                  128tech                                                          20 M
 
@@ -46,7 +46,7 @@ Total download size: 25 M
 Installed size: 92 M
 Is this ok [y/N]: y
 Downloading Packages:
-(1/2): 128T-monitoring-agent-2.0.0-3.x86_64.rpm                                                                                                                                                                                24 MB/s | 5.0 MB     00:00
+(1/2): 128T-monitoring-agent-2.0.1-2.x86_64.rpm                                                                                                                                                                                24 MB/s | 5.0 MB     00:00
 (2/2): telegraf-128tech-1.14.0-1.x86_64.rpm                                                                                                                                                                                    41 MB/s |  20 MB     00:00
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Total                                                                                                                                                                                                                          40 MB/s |  25 MB     00:00
@@ -60,16 +60,16 @@ Running transaction
   Installing       : telegraf-128tech-1.14.0-1.x86_64                                                                                                                                                                                                     1/2
   Running scriptlet: telegraf-128tech-1.14.0-1.x86_64                                                                                                                                                                                                     1/2
 Created symlink from /etc/systemd/system/multi-user.target.wants/telegraf.service to /usr/lib/systemd/system/telegraf.service.
-  Installing       : 128T-monitoring-agent-2.0.0-3.x86_64                                                                                                                                                                                                 2/2
-  Running scriptlet: 128T-monitoring-agent-2.0.0-3.x86_64                                                                                                                                                                                                 2/2
+  Installing       : 128T-monitoring-agent-2.0.1-2.x86_64                                                                                                                                                                                                 2/2
+  Running scriptlet: 128T-monitoring-agent-2.0.1-2.x86_64                                                                                                                                                                                                 2/2
   Running scriptlet: telegraf-128tech-1.14.0-1.x86_64                                                                                                                                                                                                     2/2
-  Running scriptlet: 128T-monitoring-agent-2.0.0-3.x86_64                                                                                                                                                                                                 2/2
+  Running scriptlet: 128T-monitoring-agent-2.0.1-2.x86_64                                                                                                                                                                                                 2/2
 Removed symlink /etc/systemd/system/multi-user.target.wants/telegraf.service.
-  Verifying        : 128T-monitoring-agent-2.0.0-3.x86_64                                                                                                                                                                                                 1/2
+  Verifying        : 128T-monitoring-agent-2.0.1-2.x86_64                                                                                                                                                                                                 1/2
   Verifying        : telegraf-128tech-1.14.0-1.x86_64                                                                                                                                                                                                     2/2
 
 Installed:
-  128T-monitoring-agent.x86_64 2.0.0-3                                                                                            telegraf-128tech.x86_64 1.14.0-1
+  128T-monitoring-agent.x86_64 2.0.1-2                                                                                            telegraf-128tech.x86_64 1.14.0-1
 
 Complete!
 ```

--- a/docs/release_notes_monitoring_agent_1.1.md
+++ b/docs/release_notes_monitoring_agent_1.1.md
@@ -2,6 +2,24 @@
 title: 128T Monitoring Agent 1.1 Release Notes
 sidebar_label: 1.1
 ---
+## Release 1.1.1
+
+### Issues Fixed
+
+----
+- **MON-185** telegraf error when processing results from peer path input
+
+  _**Resolution:**_ The extra logging causing the problem was removed
+------
+- **MON-186** LTE metric collector not reporting any values
+
+  _**Resolution:**_ Updated the library imports and identifiers used to display the missing data
+------
+- **MON-188** The events inputs collector has invalid sample
+
+  _**Resolution:**_ Updated the sample and staged configuration example for events
+
+
 ## Release 1.1.0
 
 ### New Features and Improvements

--- a/docs/release_notes_monitoring_agent_2.0.md
+++ b/docs/release_notes_monitoring_agent_2.0.md
@@ -2,6 +2,24 @@
 title: 128T Monitoring Agent 2.0 Release Notes
 sidebar_label: '2.0'
 ---
+## Release 2.0.1
+
+### Issues Fixed
+
+----
+- **MON-185** telegraf error when processing results from peer path input
+
+  _**Resolution:**_ The extra logging causing the problem was removed
+------
+- **MON-186** LTE metric collector not reporting any values
+
+  _**Resolution:**_ Updated the library imports and identifiers used to display the missing data
+------
+- **MON-188** The events inputs collector has invalid sample
+
+  _**Resolution:**_ Updated the sample and staged configuration example for events
+
+
 ## Release 2.0.0
 
 ### New Features and Improvements


### PR DESCRIPTION
Fix a couple of bugs affecting 1.1.0 and 2.0.0 version of the monitoring-agent.
Updated the release notes with the data on the issues fixed

DOCS-86 #time 20m