### PR TITLE
Fixed order of release sections in ipsec client release notes

### DIFF
--- a/docs/release_notes_128t_ipsec_client_1.0.md
+++ b/docs/release_notes_128t_ipsec_client_1.0.md
@@ -6,11 +6,6 @@ sidebar_label: '1.0'
 ## Special Considerations
 This version of the plugin is compatible with any 128T version less than 4.3 and greater than or equal to 3.2.8.
 
-## Release 1.0.1
-
-### Issues Fixed
-- **PLUGIN-47** Created generic IPSEC client plugin to provide connectivity to remote IPSEC endpoints. This version supports a single client with up to two remote endpoints.
-
 
 ## Release 1.0.4
 
@@ -20,3 +15,9 @@ This version of the plugin is compatible with any 128T version less than 4.3 and
 - **PLUGIN-333** The `plugin-network` ip prefix setting in the configuration was ignored and would instead use the default ip prefix setting.
 - **PLUGIN-336** Using the `vector-name` configuration option would generate invalid configuration.
 - **PLUGIN-400** Added a local subnet configuration option and enhanced the remote subnet configuration option to allow a list of values.
+
+
+## Release 1.0.1
+
+### Issues Fixed
+- **PLUGIN-47** Created generic IPSEC client plugin to provide connectivity to remote IPSEC endpoints. This version supports a single client with up to two remote endpoints.

--- a/docs/release_notes_128t_ipsec_client_2.0.md
+++ b/docs/release_notes_128t_ipsec_client_2.0.md
@@ -6,12 +6,6 @@ sidebar_label: '2.0'
 ## Special Considerations
 This version of the plugin is compatible with any 128T version less than 4.5 and greater than or equal to 4.3.
 
-## Release 2.0.1
-
-### Issues Fixed
-
-- **PLUGIN-47** Created generic ipsec client plugin to provide connectivity to remote ipsec endpoints. This version supports a single client with up to two remote endpoints.
-
 
 ## Release 2.0.4
 
@@ -21,3 +15,10 @@ This version of the plugin is compatible with any 128T version less than 4.5 and
 - **PLUGIN-333** The `plugin-network` ip prefix setting in the configuration was ignored and would instead use the default ip prefix setting.
 - **PLUGIN-336** Using the `vector-name` configuration option would generate invalid configuration.
 - **PLUGIN-400** Added a local subnet configuration option and enhanced the remote subnet configuration option to allow a list of values.
+
+
+## Release 2.0.1
+
+### Issues Fixed
+
+- **PLUGIN-47** Created generic ipsec client plugin to provide connectivity to remote ipsec endpoints. This version supports a single client with up to two remote endpoints.


### PR DESCRIPTION
The release sections were in oldest first order so I switched them to be newest first