### PR TITLE
added google analytics

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -28,6 +28,11 @@ module.exports = {
       indexName: '128technology',
       algoliaOptions: {},
     },
+    googleAnalytics: {
+      trackingID: 'UA-167298415-2',
+      // Optional fields.
+      anonymizeIP: true, // Should IPs be anonymized?
+    },
   },
   presets: [
     [


### PR DESCRIPTION
This adds a google analytics with our tracking ID, per https://v2.docusaurus.io/docs/using-plugins/#docusaurusplugin-google-analytics