### PR TITLE
Update links in plugin documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Alternatively if you prefer, you can run the server just with `docker`.
 1. Ensure you have installed `docker`.
 2. Run `docker image build -t 128t-docs .` to build the image.
 3. Run `docker create --name 128t-docs --publish 3000:3000 128t-docs` to create the container.
-4. Run `docker start -a 128t-docs `to start the container.
+4. Run `docker start -a 128t-docs` to start the container.
 
 That's it. Point a browser to http://localhost:3000 to see the fruits of your labor.
 

--- a/docs/concepts_kni.md
+++ b/docs/concepts_kni.md
@@ -59,7 +59,7 @@ The above configuration, creates a KNI called `host-kni` in Linux which can be u
        valid_lft forever preferred_lft forever
 ```
 
-Users can also configure a `network-namespace` for the host KNI which is useful for isolating the host KNI into a namespace and is commonly how KNIs are used. Applications and plugins leverage the [scripting framework](#scripting-framework) in order to implement [SFC](plugin_intro#service-function-chaining). To simplify the adoption of this model and to speed up plugin development using this model, [a utility with a set of namespace scripts](plugin_kni_namespace_scripts) is provided to simplify this process.
+Users can also configure a `network-namespace` for the host KNI which is useful for isolating the host KNI into a namespace and is commonly how KNIs are used. Applications and plugins leverage the [scripting framework](#scripting-framework) in order to implement [SFC](plugin_intro.md#service-function-chaining). To simplify the adoption of this model and to speed up plugin development using this model, [a utility with a set of namespace scripts](plugin_kni_namespace_scripts.md) is provided to simplify this process.
 
 
 ### Bridge KNI
@@ -119,7 +119,7 @@ In this mode, the 128T router will create a Linux bridge (of the form `kni<globa
 
 
 ## Scripting Framework
-The KNI scripting framework provides a programmable interface to bring-up, initialize and monitor applications that are associated with KNIs. Several of the built in device types such as LTE, PPPoE and T1 all leverage this framework to implement majority of their functions. Other features in the product such as DHCP server and [plugins](plugin_intro#service-function-chaining) also leverage this scripting framework.
+The KNI scripting framework provides a programmable interface to bring-up, initialize and monitor applications that are associated with KNIs. Several of the built in device types such as LTE, PPPoE and T1 all leverage this framework to implement majority of their functions. Other features in the product such as DHCP server and [plugins](plugin_intro.md#service-function-chaining) also leverage this scripting framework.
 
 ### Directory structure
 The scripting framework scans for executable scripts in the `/etc/128technology/plugins/network-scripts` directory for each of the configured types. Each of the built in type has its own dedicated sub-directory called `lte`, `pppoe` and `t1` where the router stages the necessary scripts. For the `host` type interface, the software will look for scripts in a sub-directory by the name of the KNI interface under `/etc/128technology/plugins/network-scripts/host/`. For the `bridge` type interface, the software will look for a scripts in a sub-directory by the name of the `target-interface` under `/etc/128technology/plugins/network-scripts/bridged/`. From the above example, this will be `128technology/plugins/network-scripts/host/host-kni` and `/etc/128technology/plugins/network-scripts/bridged/dpdk3` respectively.

--- a/docs/plugin_dns_app_id.md
+++ b/docs/plugin_dns_app_id.md
@@ -8,7 +8,7 @@ The DNS App ID plugin will identify traffic passing through your 128T router by 
 This plugin will rely on the [DNS Cache](plugin_dns_cache.md) plugin for hostname resolution.
 
 :::note
-The instructions for installing and managing the plugin can be found [here](plugin_intro#installation-and-management).
+The instructions for installing and managing the plugin can be found [here](plugin_intro.md#installation-and-management).
 :::
 
 ## Configuration

--- a/docs/plugin_dns_cache.md
+++ b/docs/plugin_dns_cache.md
@@ -10,7 +10,7 @@ lan-intf (lan-tenant) > `ingress-service` > `dnsmasq` > dns-kni (`tenant`) > egr
 By enabling this plugin, you can provide DNS caching with fast resolution times to your network.
 
 :::note
-The instructions for installing and managing the plugin can be found [here](plugin_intro#installation-and-management).
+The instructions for installing and managing the plugin can be found [here](plugin_intro.md#installation-and-management).
 :::
 
 ## Configuration

--- a/docs/plugin_gre.md
+++ b/docs/plugin_gre.md
@@ -6,7 +6,7 @@ sidebar_label: GRE
 The 128T GRE plugin can be used for creating IPv4 GRE tunnels between a 128T router and a remote GRE tunnel destination. For services such as Zscaler, this provides better throughput compared to other tunneling mechanisms.
 
 :::note
-The instructions for installing and managing the plugin can be found [here](plugin_intro#installation-and-management).
+The instructions for installing and managing the plugin can be found [here](plugin_intro.md#installation-and-management).
 :::
 
 ## Configuration

--- a/docs/plugin_intro.md
+++ b/docs/plugin_intro.md
@@ -11,14 +11,14 @@ sidebar_label: Introduction
 
 
 ## Plugin Workflow
-Plugins enable a variety of use cases to be implemented to enhance the 128T router experience. These plugins can range from something as simple as managing system settings on the router like the `128T-journal` plugin for managing systemd journal size to something more advanced such as [`128T-ipsec-client`](plugin_ipsec_client) which allows for the creation and management of IPSec client tunnels on the 128T router. Regardless of the usage and the complexity of the plugin they follow a general workflow.
+Plugins enable a variety of use cases to be implemented to enhance the 128T router experience. These plugins can range from something as simple as managing system settings on the router like the `128T-journal` plugin for managing systemd journal size to something more advanced such as [`128T-ipsec-client`](plugin_ipsec_client.md) which allows for the creation and management of IPSec client tunnels on the 128T router. Regardless of the usage and the complexity of the plugin they follow a general workflow.
 
 ### Installation and management
 The 128T conductor GUI provides a dashboard to view and manage all available plugins.
 
 ![128T Plugin Dasboard](/img/plugins_dashboard.png)
 
-The dashboard above shows the available and installed plugins. The [`128T-dns-cache`](plugin_dns_cache) plugin in the dashboard above is available and ready to be installed on the conductor. The [`128T-gre`](plugin_gre) plugin shows a green icon meaning it has been installed and ready to be configured. The [`128T-ipsec-client`](plugin_ipsec_client) plugin has an orange icon indicating that a new version of the plugin is available for installation, though the currently installed version is still actively being used by the conductor.
+The dashboard above shows the available and installed plugins. The [`128T-dns-cache`](plugin_dns_cache.md) plugin in the dashboard above is available and ready to be installed on the conductor. The [`128T-gre`](plugin_gre.md) plugin shows a green icon meaning it has been installed and ready to be configured. The [`128T-ipsec-client`](plugin_ipsec_client.md) plugin has an orange icon indicating that a new version of the plugin is available for installation, though the currently installed version is still actively being used by the conductor.
 
 :::important
 Upon installation, removal or upgrade of a plugin, the Conductor must be restarted for the changes to take effect.
@@ -41,7 +41,7 @@ Installed plugin can be removed from the UI by using the `Uninstall` button on t
 ![128T Plugin Uninstall](/img/plugin_uninstall.gif)
 
 ### Enabling plugin-specific configuration
-The conductor provides extensibility APIs through which plugins can add plugin-specific configuration to the 128T conductor. This mechanism is especially useful for collecting various user inputs to drive the plugin behavior. For example, the [`128T-gre`](plugin_gre) uses the configuration to obtain tunnel configuration for the router.
+The conductor provides extensibility APIs through which plugins can add plugin-specific configuration to the 128T conductor. This mechanism is especially useful for collecting various user inputs to drive the plugin behavior. For example, the [`128T-gre`](plugin_gre.md) uses the configuration to obtain tunnel configuration for the router.
 
 ![128T GRE configuration](/img/plugin_gre_config.gif)
 
@@ -59,10 +59,10 @@ Plugins rely on connectivity between the conductor and router to drive their log
 :::
 
 ## Plugin Concepts
-Some of the more advanced plugins such as [`128T-ipsec-client`](plugin_ipsec_client) and [`128T-gre`](plugin_gre) rely on various extensibility features available on the router to perform their functions. Some of the commonly used concepts are as follows.
+Some of the more advanced plugins such as [`128T-ipsec-client`](plugin_ipsec_client.md) and [`128T-gre`](plugin_gre.md) rely on various extensibility features available on the router to perform their functions. Some of the commonly used concepts are as follows.
 
 ### KNI network scripts
-[The Kernel Network Interface (KNI)](https://doc.dpdk.org/guides/prog_guide/kernel_nic_interface.html) is a special interface which allows for communication between 128T router and the underlying operating system. Most common instance of KNI is the presence of a loopback interface called `kni254` on the system which is typically used to enable in-band management sessions on a 128T router. KNIs also provide an extensive set of [scripting functionality](plugin_kni_namespace_scripts) which can be used to drive additional applications on the system such as DNS masquerade, ipsec-client using libreswan, GRE stack in linux OS etc. A more detailed guide on KNI interface scripting can be found [here](concepts_kni).
+[The Kernel Network Interface (KNI)](https://doc.dpdk.org/guides/prog_guide/kernel_nic_interface.html) is a special interface which allows for communication between 128T router and the underlying operating system. Most common instance of KNI is the presence of a loopback interface called `kni254` on the system which is typically used to enable in-band management sessions on a 128T router. KNIs also provide an extensive set of [scripting functionality](plugin_kni_namespace_scripts.md) which can be used to drive additional applications on the system such as DNS masquerade, ipsec-client using libreswan, GRE stack in linux OS etc. A more detailed guide on KNI interface scripting can be found [here](concepts_kni.md).
 
 ### Service Function Chaining
 One of the most common use case for plugins is the notion of service function chaining whereby `ingress` traffic (typically from a lan interface) is routed through the linux OS to be passed through a `service function` which can be used to inspect, encapsulate, transform or provide additional functionality on the incoming traffic. Once the service function in linux is applied it will result in a new set of sessions being created towards the `egress` interfaces (typically towards a wan interface). Such a SFC function relies on the safe and reliable 128T Session Smart routing in both directions.
@@ -76,4 +76,4 @@ Consider appropriate tenancy for each side of the traffic (ingress vs egress) to
 :::
 
 ### Application Identification
-128T router have powerful application-based routing capabilities using [modules](concepts_appid#appid-using-modules) which can provide a name to ip-prefix mapping. As the documentation suggests, the module based approach requires programming expertise and as a result lends itself very well as a plugin. Several plugins utilize the app-id feature in the product to provide a meaningful user experience. The [`128T-dns-app-id`](plugin_dns_app_id) plugin, for example, combines both the SFC concept as described [above](#service-function-chaining) in order to learn and cache DNS records routed through the 128T platform as well as leveraging the learned information to provide named routing for applications such as GSuite, Gmail etc by leveraging application-id.
+128T router have powerful application-based routing capabilities using [modules](concepts_appid.md#appid-using-modules) which can provide a name to ip-prefix mapping. As the documentation suggests, the module based approach requires programming expertise and as a result lends itself very well as a plugin. Several plugins utilize the app-id feature in the product to provide a meaningful user experience. The [`128T-dns-app-id`](plugin_dns_app_id.md) plugin, for example, combines both the SFC concept as described [above](#service-function-chaining) in order to learn and cache DNS records routed through the 128T platform as well as leveraging the learned information to provide named routing for applications such as GSuite, Gmail etc by leveraging application-id.

--- a/docs/plugin_ipsec_client.md
+++ b/docs/plugin_ipsec_client.md
@@ -3,10 +3,10 @@ title: IPsec Client plugin
 sidebar_label: IPsec Client
 ---
 
-The 128T-ipsec-client plugin provides a way to send and encrypt traffic to IPsec endpoints through the 128T router. It is possible to configure the plugin for each router to have multiple destination IPsec endpoints and thus the 128T will failover between them. This is accomplished by performing a [Service Function Chain (SFC)](plugin_intro#service-function-chaining) with Libreswan, a third-party IPsec client. By enabling this plugin, you can provide IPsec tunnel connectivity to third party providers from your 128T router.
+The 128T-ipsec-client plugin provides a way to send and encrypt traffic to IPsec endpoints through the 128T router. It is possible to configure the plugin for each router to have multiple destination IPsec endpoints and thus the 128T will failover between them. This is accomplished by performing a [Service Function Chain (SFC)](plugin_intro.md#service-function-chaining) with Libreswan, a third-party IPsec client. By enabling this plugin, you can provide IPsec tunnel connectivity to third party providers from your 128T router.
 
 :::note
-The instructions for installing and managing the plugin can be found [here](plugin_intro#installation-and-management).
+The instructions for installing and managing the plugin can be found [here](plugin_intro.md#installation-and-management).
 :::
 
 ## Configuration
@@ -48,7 +48,7 @@ router
 exit
 ```
 
-:::note 
+:::note
 This plugin can only connect to IPsec endpoints that support pre-shared key authentication.
 :::
 
@@ -80,7 +80,7 @@ node
 exit
 ```
 
-:::note 
+:::note
 Only one `ipsec-client` can be configured per node, but two `remote`s can be configured per client.
 :::
 
@@ -302,7 +302,7 @@ exit
 
 ## Troubleshooting
 
-### Data Model 
+### Data Model
 If the data model doesn’t appear in the PCLI or GUI, make sure that you have restarted the 128T service.
 
 ### Logging

--- a/docs/plugin_kni_namespace_scripts.md
+++ b/docs/plugin_kni_namespace_scripts.md
@@ -3,7 +3,7 @@ title: Kernel Network Namespace Scripts
 sidebar_label: KNI Namespace Scripts
 ---
 
-As part of plugin development to extend the functionality of a 128T router, a very common model is to leverage [KNI (Kernel Network Interface)](concepts_kni) along with Linux network namespaces. They allow for isolation of various networking components such as interfaces, routing table, iptables, etc., while running applications that leverage these networking namespaces. This is also very common method to deploy [Service Function Chaining](plugin_intro#service-function-chaining) within the product.
+As part of plugin development to extend the functionality of a 128T router, a very common model is to leverage [KNI (Kernel Network Interface)](concepts_kni) along with Linux network namespaces. They allow for isolation of various networking components such as interfaces, routing table, iptables, etc., while running applications that leverage these networking namespaces. This is also very common method to deploy [Service Function Chaining](plugin_intro.md#service-function-chaining) within the product.
 
 The goal of this package is to provide a set of scripts which do most of the tasks when it comes to setting up the namespaces and associated environment.
 
@@ -130,7 +130,7 @@ target-interface:
 The `default-route` flag is used to set the target-interface as a `default` route with zero metric in the namespace making it the preferred choice for routing all traffic.
 
 ### Application Definition
-Any [SFC application](plugin_intro#service-function-chaining) will require some applications to run within the namespace to consume the KNI and other network resources. This configuration provides a list of commands to be run within the namespace.
+Any [SFC application](plugin_intro.md#service-function-chaining) will require some applications to run within the namespace to consume the KNI and other network resources. This configuration provides a list of commands to be run within the namespace.
 
 :::note
 The scripts will automatically append `ip netns exec` for every configured command.
@@ -189,7 +189,7 @@ The `default` keyword is used to create route entries for the default route tabl
 * from-prefix (from)
 * to-prefix (to)
 
-:::note 
+:::note
 The rules defined under `routing` will be applied before any `route-tables`. Since the `route-tables` supersede the functionality of `routing` it is not recommended to use both in the same config.
 :::
 

--- a/docs/plugin_kni_namespace_scripts.md
+++ b/docs/plugin_kni_namespace_scripts.md
@@ -3,18 +3,18 @@ title: Kernel Network Namespace Scripts
 sidebar_label: KNI Namespace Scripts
 ---
 
-As part of plugin development to extend the functionality of a 128T router, a very common model is to leverage [KNI (Kernel Network Interface)](concepts_kni) along with Linux network namespaces. They allow for isolation of various networking components such as interfaces, routing table, iptables, etc., while running applications that leverage these networking namespaces. This is also very common method to deploy [Service Function Chaining](plugin_intro.md#service-function-chaining) within the product.
+As part of plugin development to extend the functionality of a 128T router, a very common model is to leverage [KNI (Kernel Network Interface)](concepts_kni.md) along with Linux network namespaces. They allow for isolation of various networking components such as interfaces, routing table, iptables, etc., while running applications that leverage these networking namespaces. This is also very common method to deploy [Service Function Chaining](plugin_intro.md#service-function-chaining) within the product.
 
 The goal of this package is to provide a set of scripts which do most of the tasks when it comes to setting up the namespaces and associated environment.
 
 ## Scripts
-The following scripts are part of the package and have a well-defined role as described [here](concepts_kni#script-types).
+The following scripts are part of the package and have a well-defined role as described [here](concepts_kni.md#script-types).
 
 ### startup
 This script is invoked at the beginning of the KNI creation and is intended to do clean-up. In the current implementation this script will stop the configured [application](#application-definition) (if any).
 
 ### init
-The [init script](concepts_kni#init) is responsible for the majority of the setup. The script performs the following high-level function:
+The [init script](concepts_kni.md#init) is responsible for the majority of the setup. The script performs the following high-level function:
 
 - Create the configured network-namespace in Linux as per 128T requirements.
 - Move and setup any configured target-interface into the namespace
@@ -23,17 +23,17 @@ The [init script](concepts_kni#init) is responsible for the majority of the setu
 - Setup routes and iptable rules
 
 ### reinit
-The [reinit](concepts_kni#reinit) script is called when the interface is deemed to be down for more than 10 seconds. For the sake of this implementation we simply symlink the `reinit` to `init` script
+The [reinit](concepts_kni.md#reinit) script is called when the interface is deemed to be down for more than 10 seconds. For the sake of this implementation we simply symlink the `reinit` to `init` script
 
 ### shutdown
-The [shutdown](concepts_kni#shutdown) script is called during 128T shutdown or deletion of the interface. This script will stop the configured [application](#application-definition) (if any) and delete the network namespace
+The [shutdown](concepts_kni.md#shutdown) script is called during 128T shutdown or deletion of the interface. This script will stop the configured [application](#application-definition) (if any) and delete the network namespace
 
 ### Installation
 The `t128-kni-namespace-scripts` package contains all the scripts mentioned [above](#scripts). Upon installation, the scripts in this package are placed under `/etc/128technology/plugins/network-scripts/default/kni_namespace/` with the right set of permissions and settings required for operation by 128T router.
 
 
 ### Symlink To KNI scripts ##
-The package only contains a subset of the scripts provided by the [network-script design](concepts_kni#script-types). There are other scripts such as state, info, monitoring, etc., which are not covered in this package. As a result, the best practice is to symlink the host KNI scripts to the pre-packaged scripts listed [above](#scripts).
+The package only contains a subset of the scripts provided by the [network-script design](concepts_kni.md#script-types). There are other scripts such as state, info, monitoring, etc., which are not covered in this package. As a result, the best practice is to symlink the host KNI scripts to the pre-packaged scripts listed [above](#scripts).
 
 For example, for a configuration with a `host` kni called `test-sfc` the scripts above would be used as follows:
 
@@ -77,7 +77,7 @@ route-tables:
 The above example shows all the possible configuration. All of these configuration are optional and reasonable defaults are assumed. Each of the sections below discuss the options in more details.
 
 ### Variable Substitution
-The configuration supports basic variable substitutions which directly map to the [arguments passed to the network-scripts](concepts_kni#script-command-line-arguments) by 128T router. The following keywords can be used in the config and will be substituted with the correct arguments at runtime.
+The configuration supports basic variable substitutions which directly map to the [arguments passed to the network-scripts](concepts_kni.md#script-command-line-arguments) by 128T router. The following keywords can be used in the config and will be substituted with the correct arguments at runtime.
 
 Consider the following configuration
 ```config

--- a/docs/plugin_mosh.md
+++ b/docs/plugin_mosh.md
@@ -6,7 +6,7 @@ sidebar_label: Mosh
 The Mosh plugin provides the ability to install the MObile SHell [MOSH](https://mosh.org/) on 128T nodes.  Mosh is provided under GNU GPLv3.
 
 :::note
-The instructions for installing and managing the plugin can be found [here](plugin_intro#installation-and-management).
+The instructions for installing and managing the plugin can be found [here](plugin_intro.md#installation-and-management).
 :::
 
 ## Configuration

--- a/docs/plugin_sip_alg.md
+++ b/docs/plugin_sip_alg.md
@@ -8,7 +8,7 @@ The Session Initiation Protocol (SIP)[^1] is a signaling protocol used for initi
 When 128T router is present at the edge of the NAT boundary, it is capable of performing a Application Layer Gateway (ALG) function for SIP protocol by doing packet inspection and re-writing the private IP address information in the SIP messages for both SIP headers and Session Description Protocol (SDP)[^2]. This enables both signaling and media traffic to traverse the NAT and makes the communication possible between the client behind the NAT and the remote SIP endpoint(s). The SIP ALG function can be enabled by installing and configuring the `128T-sip-alg` plugin.
 
 :::note
-The instructions for installing and managing the plugin can be found [here](plugin_intro#installation-and-management).
+The instructions for installing and managing the plugin can be found [here](plugin_intro.md#installation-and-management).
 :::
 
 


### PR DESCRIPTION
- update links to plugin_ingo page missing .md file extension
- links to headers within another file require both file name and
extension, plus the header