### PR TITLE
DOCS-202 fixed misleading text #time 10m

### DIFF
--- a/docs/config_rate_limiting.md
+++ b/docs/config_rate_limiting.md
@@ -63,7 +63,13 @@ Since 128T services are directional, it is important to be able to control the d
 
 Once the rate-limit-policy is defined, in order for it to be applied to a service, `aggregate-rate-limit-policy` must be defined in the `service-class`.
 
+:::note
+The `rate-limit` field in a `service-class` is only used when configuring *per-flow rate limiting*, it is not necessary to set this to `true` to enable *per-service rate limiting*.
+:::
+
+:::note
 Flow rate limiting and aggregate rate limiting can configured independently of each other. When both `rate-limit` and `aggregate-rate-limit-policy` are enabled in the `service-class`, flow rate limiting will be applied first, before aggregate rate limiting.
+:::
 
 Sample configuration:
 
@@ -83,7 +89,6 @@ exit
 
 service-class   rate-policy-class
     name                         rate-policy-class
-    rate-limit                   true
     aggregate-rate-limit-policy  rate-limiting
 exit
 


### PR DESCRIPTION
A partner configured per-service rate limiting according to our docs and enabled **rate-limit** in the service-class. The result was that they took down traffic for a specific service at every branch location, not realizing that rate-limit applies to per-flow rate limiting.

Our documentation showed the field as enabled unnecessarily.