### PR TITLE
Added Release Notes API Plugin

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,12 +24,20 @@ module.exports = {
       logo: {
         alt: 'Juniper Logo',
         src: 'img/logo.svg',
-        srcDark: 'img/logo_dark.png'
+        srcDark: 'img/logo_dark.png',
       },
       items: [
         {to: 'docs/intro_getting_started', label: 'Docs', position: 'right'},
-        {href: 'https://community.128technology.com/home', label: 'Interchange', position: 'right'},
-        {href: 'https://www.128technology.com/', label:'Company', position: 'right'},
+        {
+          href: 'https://community.128technology.com/home',
+          label: 'Interchange',
+          position: 'right',
+        },
+        {
+          href: 'https://www.128technology.com/',
+          label: 'Company',
+          position: 'right',
+        },
       ],
     },
     footer: {
@@ -61,4 +69,5 @@ module.exports = {
       },
     ],
   ],
+  plugins: ['./src/plugins/release-notes-api.js'],
 };

--- a/src/plugins/release-notes-api.js
+++ b/src/plugins/release-notes-api.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+const util = require('util');
+
+const readFile = util.promisify(fs.readFile);
+const readdir = util.promisify(fs.readdir);
+const writeFile = util.promisify(fs.writeFile);
+const mkdir = util.promisify(fs.mkdir);
+const fsExists = util.promisify(fs.exists);
+
+module.exports = function releaseNotesPlugin() {
+  return {
+    name: 'release-notes-api',
+    async postBuild({outDir, siteDir}) {
+      const docsDir = path.join(siteDir, 'docs');
+      const docs = await readdir(docsDir);
+
+      const releaseNotes = docs.filter(x =>
+        /release_notes_128t_\d+\.\d+\.md$/.test(x),
+      );
+
+      const apiDir = path.join(outDir, 'api');
+      if (!(await fsExists(apiDir))) {
+        await mkdir(apiDir);
+      }
+
+      const jobs = releaseNotes.map(async note => {
+        const content = await readFile(path.join(docsDir, note), 'utf8');
+        const data = JSON.stringify({content});
+
+        await writeFile(
+          path.join(outDir, 'api', note.replace(/\.md$/, '.json')),
+          data,
+        );
+      });
+
+      await Promise.all(jobs);
+    },
+  };
+};


### PR DESCRIPTION
We want to pull release notes into our product upon login. Ideally, pulling in the markdown file is enough since we can apply the transform to convert it to HTML and then style it within our product. However, because Docusaurus converts all markdown to static HTML pages it means the only way to pull that information is to get the entire HTML which is not going work. 

This plugin simply creates static JSON files out of the contents of the release notes markdown files. In the future we may decompose the markdown further into separate JSON fields, or maybe even write release notes in JSON and convert to markdown - who knows! Either way, this provides us a way to get just the release notes content via non-converted static assets.