### PR TITLE
Removed I95-41227 from 5.1.5 release notes.

### DIFF
--- a/docs/release_notes_128t_5.1.md
+++ b/docs/release_notes_128t_5.1.md
@@ -116,8 +116,6 @@ Alternatively, refer to the **[List of Releases](about_releases.md)** page for r
 ------
 - **I95-41214 GUI Table visual issues:** All tables now use the full height of their container.
 ------
-- **I95-41227 Vulnerability Report Issues:** All identified CVE's have been addressed.
-------
 - **I95-41235 Router state indicator is not consistent across pages:** Resolved an issue where the Status Indicator was always showing unknown.
 ------
 - **I95-41270 show dhcp v6 and prefix-delegation commands not working:** This issue has been resolved. 


### PR DESCRIPTION
I95-42217 should not have been included as it is not applicable to the 5.1.0+ releases. This is an artifact of the JiraBucket script incorrectly adding `Delivered To` to the issue.