### PR TITLE
Kagrawal/docs 273/5.4.0 plugin updates

### DIFF
--- a/docs/plugin_dns_app_id.md
+++ b/docs/plugin_dns_app_id.md
@@ -337,6 +337,10 @@ exit
 
 ## Release Notes
 
+:::warning
+The plugin must be updated to version 3.1.3 or later prior to upgrading the conductor to SSR version 5.4.0.
+:::
+
 ### Release 3.1.3
 
 #### Issues Fixed

--- a/docs/plugin_dns_app_id.md
+++ b/docs/plugin_dns_app_id.md
@@ -337,6 +337,18 @@ exit
 
 ## Release Notes
 
+### Release 3.1.3
+
+#### Issues Fixed
+
+- **PLUGIN-1461**  Config generation for the plugin failing in the Bonsai mode
+
+  _**Resolution:**_ Correctly handle the config generation for routers where the plugin is not enabled during bonsai config generation
+
+- **PLUGIN-1226**  DNS App Id state script takes too long to execute
+
+  _**Resolution:**_ Optimized the execution of the script by simplifying some of the plugin router components.
+
 ### Release 2.3.1, 3.1.1
 
 #### Issues Fixed

--- a/docs/plugin_dns_cache.md
+++ b/docs/plugin_dns_cache.md
@@ -173,6 +173,18 @@ Verify that the dns-cache network interface (default `dns-cache-intf`) is UP.
 
 ## Release Notes
 
+### Release 3.2.1
+
+#### Issues Fixed
+
+- **PLUGIN-1461**  Config generation for the plugin failing in the Bonsai mode
+
+  _**Resolution:**_ Correctly handle the config generation for routers where the DNS cache plugin is not enabled during bonsai config generation
+
+- **PLUGIN-1367**  DNS cache services constantly fail on system startup
+
+  _**Resolution:**_ The DNS cache systemd services will be deferred until the 128T services are running and stable.
+
 ### Release 3.1.0
 
 #### Issues Fixed

--- a/docs/plugin_dns_cache.md
+++ b/docs/plugin_dns_cache.md
@@ -173,6 +173,10 @@ Verify that the dns-cache network interface (default `dns-cache-intf`) is UP.
 
 ## Release Notes
 
+:::warning
+The plugin must be updated to version 3.2.1 or later prior to upgrading the conductor to SSR version 5.4.0.
+:::
+
 ### Release 3.2.1
 
 #### Issues Fixed

--- a/docs/plugin_ha_sync_redundancy.md
+++ b/docs/plugin_ha_sync_redundancy.md
@@ -228,6 +228,10 @@ If these scripts have errors, they will be shown in `/var/log/128technology/high
 
 ## Release Notes
 
+:::warning
+The plugin must be updated to version 1.1.0 or later prior to upgrading the conductor to SSR version 5.4.0.
+:::
+
 ### Release 1.1.0
 
 #### Issues Fixed

--- a/docs/plugin_ha_sync_redundancy.md
+++ b/docs/plugin_ha_sync_redundancy.md
@@ -56,7 +56,7 @@ Additionally there is typically a desire to minimize the number of cables that r
 
 ## Troubleshooting
 
-### Config Auto-Generation 
+### Config Auto-Generation
 When enabling use of the shared fabric interface, this plugin auto-generates configuration for a kni host interface named `ha-fabric`. If expected configuration is not being generated, please check the following log on the conductor for errors.
 ```
 /var/log/128technology/plugins/ha-sync-redundancy-generate-configuration.log
@@ -225,3 +225,13 @@ lrwxrwxrwx 1 root root  72 Aug 30 20:26 startup -> /etc/128technology/plugins/ne
 ```
 
 If these scripts have errors, they will be shown in `/var/log/128technology/highway.log`. On occasion, setting the log-level to debug will provide additional details of how these scripts are run and errors they generate.
+
+## Release Notes
+
+### Release 1.1.0
+
+#### Issues Fixed
+
+- **PLUGIN-1451**  Config generation for the plugin failing in the Bonsai mode
+
+  _**Resolution:**_ Correctly handle the config generation for routers where the plugin is not enabled during bonsai config generation


### PR DESCRIPTION
The following plugins needs upgrading prior to installing 5.4.0. Applies to any conductors running 5.1 or 5.2 software

- dns-cache
- dns-app-id
- ha-sync-redundancy