### PR TITLE
resolving DOCS-274 notes unreadable in dark mode.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -17,7 +17,7 @@ module.exports = {
 
       // Should we use the prefers-color-scheme media-query,
       // using user system preferences, instead of the hardcoded defaultMode
-      respectPrefersColorScheme: true,
+      respectPrefersColorScheme: false,
     },
     navbar: {
       title: 'Session Smart',


### PR DESCRIPTION
This resolves the issue of Notes displaying white text against a gray background rendering them unreadable. It also prevents documentation from displaying in dark mode, which is counter to the rest of Juniper documentation.