### PR TITLE
Changed feature name for bfd tunnel

### DIFF
--- a/docs/config_bfd_tunnel.md
+++ b/docs/config_bfd_tunnel.md
@@ -1,9 +1,9 @@
 ---
-title: BFD Overlay over SVR
-sidebar_label: BFD Overlay over SVR
+title: SVR Transport Reuse
+sidebar_label: SVR Transport Reuse
 ---
 
-In deployments where the number of SVR sessions between SSRs are limited due to provider settings, the established BFD channel is leveraged to encapsulate SVR sessions. When enabled, the SSR transforms each packet in the SVR session to a UDP packet, matching the IP/Port tuples of the BFD peer connection. The carrier does not see any additional sessions between the SSRs beyond the initial BFD peer connection. 
+In deployments where the number of SVR sessions between SSRs are limited due to provider settings, the established BFD transport session is reused to carry SVR sessions. When enabled, the SSR transforms each packet in the SVR session to a UDP packet, matching the IP/Port tuples of the BFD peer connection. The carrier does not see any additional sessions between the SSRs beyond the initial BFD peer connection. 
 
 ## Configuration
 
@@ -13,7 +13,7 @@ This feature is accessed from Authority > Router > Node > Device > Network Inter
 Use the path described above to access the Neighborhood configuration. After naming the neighborhood, choose the `spoke` topology type. This opens the Peer Path Overlay field. The following options are available:
 
 - **svr**: The original SVR overlay connection method. This is the default method for bidirectional connectivity. 
-- **bfd-tunnel**: Outbound only connection method; enables the BFD Overlay over SVR feature. 
+- **bfd-tunnel**: Outbound only connection method; enables the SVR Transport Reuse feature. 
 
 ![BFD Tunnel on Neighborhood](/img/config_bfd_tunnel_gui.png)
 
@@ -59,7 +59,7 @@ An attribute is added to the unencrypted metadata of UDP packets going over the 
 
  ## Troubleshooting
 
- Use the following `show stats` metrics to view and troubleshoot issues encountered with BFD Overlay over SVR:
+ Use the following `show stats` metrics to view and troubleshoot issues encountered with SVR Transport Reuse:
 
 - [`show stats packet-processing action success tunnel bfd encapsulate`](cli_stats_reference.md#show-stats-packet-processing-action-success-tunnel-bfd-encapsulate)
 - [`show stats packet-processing action success tunnel bfd decapsulate`](cli_stats_reference.md#show-stats-packet-processing-action-success-tunnel-bfd-decapsulate)

--- a/docs/release_notes_128t_6.0.md
+++ b/docs/release_notes_128t_6.0.md
@@ -64,7 +64,7 @@ The Juniper SSR team does not publicly disclose known or resolved CVEs in our pu
 	- TBW (Terabyte Written)
 	- TBW per year
 ------
-- **I95-49824 SVR Transport Reuse** In deployments where the number of SVR sessions between SSRs are limited due to carrier settings, the established BFD channel is leveraged to encapsulate SVR sessions. For details about using this feature, see [SVR Transport Reuse.](config_bfd_tunnel.md)
+- **I95-49824 SVR Transport Reuse** In deployments where the number of SVR sessions between SSRs are limited due to carrier settings, the established BFD transport session is reused to carry SVR sessions. For details about using this feature, see [SVR Transport Reuse.](config_bfd_tunnel.md)
 ------
 - **I95-50072 Support for ConnectX-6 Lx PCIe device:** Support has been added for this device.
 ------

--- a/docs/release_notes_128t_6.0.md
+++ b/docs/release_notes_128t_6.0.md
@@ -64,7 +64,7 @@ The Juniper SSR team does not publicly disclose known or resolved CVEs in our pu
 	- TBW (Terabyte Written)
 	- TBW per year
 ------
-- **I95-49824 BFD Overlay over SVR** In deployments where the number of SVR sessions between SSRs are limited due to carrier settings, the established BFD channel is leveraged to encapsulate SVR sessions. For details about using this feature, see [BFD Overlay over SVR.](config_bfd_tunnel.md)
+- **I95-49824 SVR Transport Reuse** In deployments where the number of SVR sessions between SSRs are limited due to carrier settings, the established BFD channel is leveraged to encapsulate SVR sessions. For details about using this feature, see [SVR Transport Reuse.](config_bfd_tunnel.md)
 ------
 - **I95-50072 Support for ConnectX-6 Lx PCIe device:** Support has been added for this device.
 ------

--- a/docs/release_notes_128t_6.1.md
+++ b/docs/release_notes_128t_6.1.md
@@ -178,7 +178,7 @@ The impacted sessions will time out when all packets for the failed sessions sto
 ------
 - **I95-47259 Session Setup Scaling:** The [`session-setup-scaling`](config_reference_guide.md#session-setup-scaling) feature improves the session setup rate by enabling multi-threaded processing. 
 ------
-- **I95-49824 BFD Overlay over SVR** In deployments where the number of SVR sessions between SSRs are limited due to carrier settings, the established BFD channel is leveraged to encapsulate SVR sessions. For details about using this feature, see [BFD Overlay over SVR.](config_bfd_tunnel.md)
+- **I95-49824 SVR Transport Reuse** In deployments where the number of SVR sessions between SSRs are limited due to carrier settings, the established BFD channel is leveraged to encapsulate SVR sessions. For details about using this feature, see [SVR Transport Reuse.](config_bfd_tunnel.md)
 ------
 - **I95-50159 Automatic mesh created for route-reflector topology:** Enables the generation of additional BGP service-routes for creating mesh connectivity between all clients of a route reflector. See [Service-route Mesh For Route Reflector Clients](config_bgp.md#service-route-mesh-for-route-reflector-clients) for additional information. 
 

--- a/docs/release_notes_128t_6.1.md
+++ b/docs/release_notes_128t_6.1.md
@@ -178,7 +178,7 @@ The impacted sessions will time out when all packets for the failed sessions sto
 ------
 - **I95-47259 Session Setup Scaling:** The [`session-setup-scaling`](config_reference_guide.md#session-setup-scaling) feature improves the session setup rate by enabling multi-threaded processing. 
 ------
-- **I95-49824 SVR Transport Reuse** In deployments where the number of SVR sessions between SSRs are limited due to carrier settings, the established BFD channel is leveraged to encapsulate SVR sessions. For details about using this feature, see [SVR Transport Reuse.](config_bfd_tunnel.md)
+- **I95-49824 SVR Transport Reuse** In deployments where the number of SVR sessions between SSRs are limited due to carrier settings, the established BFD transport session is reused to carry SVR sessions. For details about using this feature, see [SVR Transport Reuse.](config_bfd_tunnel.md)
 ------
 - **I95-50159 Automatic mesh created for route-reflector topology:** Enables the generation of additional BGP service-routes for creating mesh connectivity between all clients of a route reflector. See [Service-route Mesh For Route Reflector Clients](config_bgp.md#service-route-mesh-for-route-reflector-clients) for additional information. 
 


### PR DESCRIPTION
The feature name for the `bfd-tunnel` setting of `peer-path-overlay` is word salad. Better late than never, I'm proposing a more concise feature name that is also descriptive of the intended purpose of the setting. This will get the docs to reflect the naming we are wanting to use in NPI materials for the feature.