### PR TITLE
Add release notes for HA sync redundancy plugin 1.1.3

### DIFF
--- a/docs/_ha_sync_plugin_release_notes.md
+++ b/docs/_ha_sync_plugin_release_notes.md
@@ -3,6 +3,14 @@
 The plugin must be updated to version 1.1.0 or later prior to [upgrading the conductor to SSR version 5.4.0.](intro_upgrade_considerations.md#plugin-config-generation-changes)
 :::
 
+### Release 1.1.3
+
+#### Issues Fixed
+
+- **PLUGIN-2233**  VLAN ID cannot be modified
+
+  _**Resolution:**_ Add new configuration field to modify the default VLAN ID used for the interface
+
 ### Release 1.1.2
 
 #### Issues Fixed


### PR DESCRIPTION
<img width="1032" alt="Screenshot 2024-01-10 at 12 04 45 PM" src="https://github.com/128technology/docs/assets/1403603/bdecfbb2-cec7-4d60-87b5-856055db53f9">
