### PR TITLE
Fix upper value in port number range for edge routers

### DIFF
--- a/docs/config_firewall_ports.md
+++ b/docs/config_firewall_ports.md
@@ -21,7 +21,7 @@ Enable the following on your firewall for SSR to SSR connectivity:
 - [SSR IP address]
 - Port 1280/UDP
 - Ports 1280 and 1283/TCP
-- Ports in the range 16,385-65,353 TCP/UDP
+- Ports in the range 16,385-65,533 TCP/UDP
 - rp.cloud.threatseeker.com on port 443/TCP; this is required for Web Filtering
 
 For detailed information about different communication channels between nodes within a router, between peering routers, and between routers and their conductor, see [Intra- and Inter-System Communication](concepts_machine_communication.md)


### PR DESCRIPTION
The value 65,533 appears elsewhere: see _[Intra- and Inter-System Communication](https://www.juniper.net/documentation/us/en/software/session-smart-router/docs/concepts_machine_communication)_ and _[Waypoints and Waypoint Ports](https://www.juniper.net/documentation/us/en/software/session-smart-router/docs/concepts_waypoint_ports/)_.