### PR TITLE
Plugin bugfixes/features 10/31

### DIFF
--- a/docs/plugin_bgp_community_services.md
+++ b/docs/plugin_bgp_community_services.md
@@ -228,6 +228,14 @@ config authority bgp-community-services-profile O365 application OtherO365 bgp-c
 
 ## Release Notes
 
+### Release 3.0.1
+
+**Release Date:** Oct 31, 2024
+
+#### Issues Fixed
+
+- **PLUGIN-2721** Resolve on plugin downgrade config removal
+
 ### Release 3.0.0
 
 Image based install and upgrade (IBU) support for SSR 6.3.0.

--- a/docs/plugin_cloud_ha.md
+++ b/docs/plugin_cloud_ha.md
@@ -1096,6 +1096,14 @@ The following configuration is an example only - It is not for use on a system.
 
 ## Release Notes
 
+### Release 4.0.1
+
+**Release Date:** Oct 31, 2024
+
+#### Issues Fixed
+
+- **PLUGIN-2721** Resolve on plugin downgrade config removal
+
 ### Release 4.0.0
 
 Image based install and upgrade (IBU) support for SSR 6.3.0.

--- a/docs/plugin_dns_app_id.md
+++ b/docs/plugin_dns_app_id.md
@@ -341,6 +341,15 @@ exit
 The plugin must be updated to version 3.1.3 or later prior to [upgrading the conductor to SSR version 5.4.0.](intro_upgrade_considerations.md#plugin-configuration-generation-changes)
 :::
 
+### Release 4.0.1
+
+**Release Date:** Oct 31, 2024
+
+#### Issues Fixed
+
+- **PLUGIN-2699** Ensure plugin starts on system reboot or 128T restart
+- **PLUGIN-2721** Resolve on plugin downgrade config removal
+
 ### Release 4.0.0
 
 Image based install and upgrade (IBU) support for SSR 6.3.0.

--- a/docs/plugin_dns_cache.md
+++ b/docs/plugin_dns_cache.md
@@ -217,6 +217,14 @@ Verify that the dns-cache network interface (default `dns-cache-intf`) is UP.
 The plugin must be updated to version 3.2.1 or later prior to [upgrading the conductor to SSR version 5.4.0.](intro_upgrade_considerations.md#plugin-configuration-generation-changes)
 :::
 
+### Release 4.0.1
+
+**Release Date:** Oct 31, 2024
+
+#### Issues Fixed
+
+- **PLUGIN-2721** Resolve on plugin downgrade config removal
+
 ### Release 4.0.0
 
 Image based install and upgrade (IBU) support for SSR 6.3.0.

--- a/docs/plugin_http_probe.md
+++ b/docs/plugin_http_probe.md
@@ -217,7 +217,7 @@ exit
 | 2.1.0    | `http-probe-profile > up-delay-timer` introduced |
 
 
-An `up-delay-timer` can be configured on a probe to prevent a probe watching an unstable service path from coming up right away. When a probe state transitions from down to up, instead of bringing that probe up, if an `up-delay-timer` is configured the probe will be kept down until the timer finishes. If the probe goes back down while the timer is running, the timer will cancel and the probe will remain down.
+An `up-delay-timer` can be configured on a probe to prevent a probe watching an unstable service path from coming up right away. When a probe state transitions from down to up, instead of bringing that probe up, if an `up-delay-timer` is configured the probe will be kept down until the timer finishes. If the probe goes back down while the timer is running, the timer will cancel and the probe will remain down. If it is set to the default value (0) then the timer is disabled.
 
 It is recommended that a probe's `up-delay-timer` has a value greater than the `probe-interval` field. This configuration allows the probe to run at least one more time while the timer is active. A warning will be produced if a probe is configured with an `up-delay-timer` value less than the `probe-interval`. If a configuration reload occurs while a probe timer is active, the timer is honored with the previous config.
 

--- a/docs/plugin_http_probe.md
+++ b/docs/plugin_http_probe.md
@@ -219,7 +219,7 @@ exit
 
 An `up-delay-timer` can be configured on a probe to prevent a probe watching an unstable service path from coming up right away. When a probe state transitions from down to up, instead of bringing that probe up, if an `up-delay-timer` is configured the probe will be kept down until the timer finishes. If the probe goes back down while the timer is running, the timer will cancel and the probe will remain down.
 
-It is recommended that a probe's `up-delay-timer` has a value greater than the `probe-interval` field. This configuration allows the probe to run atleast one more time while the timer is active. A warning will be produced if a probe is configured with an `up-delay-timer` value less than the `probe-interval`. If a configuration reload occurs while a probe timer is active, the timer is honored with the previous config.
+It is recommended that a probe's `up-delay-timer` has a value greater than the `probe-interval` field. This configuration allows the probe to run at least one more time while the timer is active. A warning will be produced if a probe is configured with an `up-delay-timer` value less than the `probe-interval`. If a configuration reload occurs while a probe timer is active, the timer is honored with the previous config.
 
 The below example shows a probe with a configured `up-delay-timer`; with these settings, the test will be triggered every 10 seconds, 3 probes with a single probe timeout of 2 seconds will be applied and when the probe transitions from down > up it will be held down for 15 seconds.
 

--- a/docs/plugin_http_probe.md
+++ b/docs/plugin_http_probe.md
@@ -308,6 +308,23 @@ Completed in 0.05 seconds
 admin@node1.conductor1#admin@node1.conductor1#
 ```
 
+The `show plugins state router <router-name> summary 128T-http-probe` command can be used to view the current status of the probe and whether the probe is being held down. For example:
+
+```
+admin@node1.conductor1# show plugins state router my-router summary 128T-http-probe
+Wed 2024-10-02 03:19:33 UTC
+Target: node1.my-router
+
+============= ======== =========== =================
+ Probe         Status   Held Down   Time Left (sec)
+============= ======== =========== =================
+ test-probe1   up       True                      8
+ test-probe2   down     False                     0
+
+Retrieved state data.
+Completed in 0.05 seconds
+```
+
 In addition, the probe's running status in linux can be found by inspecting the `128T-http-probe-status-change-notifier@<probe-name>.service`. For example,
 
 ```
@@ -388,6 +405,20 @@ Completed in 0.21 seconds
 ```
 
 ## Release Notes
+
+### Release 2.1.0
+
+**Release Date:** Oct 31, 2024
+
+#### New Features and Improvements
+- **PLUGIN-2510** Implement an up-delay-timer
+
+The plugin allows users to configure an up-delay-timer which holds a path down for a set duration before bringing the path up.
+
+#### Issues Fixed
+
+- **PLUGIN-2629** Display stats in older (5.X) SSR releases
+- **PLUGIN-2721** Resolve on plugin downgrade config removal
 
 ### Release 2.0.0
 

--- a/docs/plugin_http_probe.md
+++ b/docs/plugin_http_probe.md
@@ -35,7 +35,7 @@ The plugin leverages the existing SSR reachability detection and enforcement con
 | probe-duration | uint32 | default: 5 | The duration (in seconds) within which to reach the destination. Each attempt will be made in (probe-duration / number-of-attempts) interval |
 | valid-status-code | list | at least 1 value required | The list of valid status codes to be expected from the server |
 | sla | container | optional | SLA requirements for http probe. See [SLA](#sla) for more information. |
-| up-delay-timer | uint32 | default: 0 | The duration (in seconds) a probe is held down before it comes up when the previous state was down |
+| up-delay-timer | uint32 | default: 0 | The duration (in seconds) a probe is held down before transitioning from down to up state |
 
 * Example:
 ```config {9-14}

--- a/docs/plugin_ipsec_client.md
+++ b/docs/plugin_ipsec_client.md
@@ -805,6 +805,14 @@ exit
 
 ## Release Notes
 
+### Release 4.0.1
+
+**Release Date:** Oct 31, 2024
+
+#### Issues Fixed
+
+- **PLUGIN-2721** Resolve on plugin downgrade config removal
+
 ### Release 4.0.0
 
 Image based install and upgrade (IBU) support for SSR 6.3.0.

--- a/docs/plugin_m800_watchdog.md
+++ b/docs/plugin_m800_watchdog.md
@@ -36,6 +36,14 @@ Feb 12 16:28:14 sol_acm800_dut1 systemd[1]: Stopped Watchdog for the Audiocodes 
 
 ## Release Notes
 
+### Release 3.0.1
+
+**Release Date:** Oct 31, 2024
+
+#### Issues Fixed
+
+- **PLUGIN-2721** Resolve on plugin downgrade config removal
+
 ### Release 3.0.0
 
 Image based install and upgrade (IBU) support for SSR 6.3.0.

--- a/docs/plugin_monitoring_agent.md
+++ b/docs/plugin_monitoring_agent.md
@@ -842,6 +842,14 @@ For syslog output, not specifying the `default_sdid` parameter can result in emp
 
 ## Monitoring Agent Plugin Release Notes
 
+### Release 4.0.1
+
+**Release Date:** Oct 31, 2024
+
+#### Issues Fixed
+
+- **PLUGIN-2721** Resolve on plugin downgrade config removal
+
 ### Release 4.0.0
 
 Image based install and upgrade (IBU) support for SSR 6.3.0.

--- a/docs/plugin_sip_alg.md
+++ b/docs/plugin_sip_alg.md
@@ -479,6 +479,14 @@ Chain POSTROUTING (policy ACCEPT 0 packets, 0 bytes)
 
 ## Release Notes
 
+### Release 4.0.1
+
+**Release Date:** Oct 31, 2024
+
+#### Issues Fixed
+
+- **PLUGIN-2721** Resolve on plugin downgrade config removal
+
 ### Release 4.0.0
 
 Image based install and upgrade (IBU) support for SSR 6.3.0.

--- a/docs/plugin_wireguard.md
+++ b/docs/plugin_wireguard.md
@@ -670,6 +670,16 @@ Dec 18 20:56:03 t211-dut2.openstacklocal python3.6[26711]: __main__ - not starti
 The plugin must be updated to version 2.0.3 or later prior to [upgrading the conductor to SSR version 5.4.0.](intro_upgrade_considerations.md#plugin-configuration-generation-changes)
 :::
 
+### Release 3.0.1
+
+**Release Date:** Oct 31, 2024
+
+#### Issues Fixed
+
+- **PLUGIN-2721** Resolve on plugin downgrade config removal
+- **PLUGIN-2727** Fix RPM removal on Conductor
+- **PLUGIN-2734** Ensure plugin starts after IBU conversion (upgrade)
+
 ### Release 3.0.0
 
 Image based install and upgrade (IBU) support for SSR 6.3.0.

--- a/docs/release_notes_wan_assurance_plugin_3.10.md
+++ b/docs/release_notes_wan_assurance_plugin_3.10.md
@@ -2,6 +2,14 @@
 title: WAN Assurance Plugin 3.10 Release Notes
 sidebar_label: '3.10'
 ---
+### Release 3.10.1
+
+**Release Date:** Oct 31, 2024
+
+### Resolved Issues
+
+- **PLUGIN-2721** Resolve on plugin downgrade config removal
+
 ### Release 3.10.0
 
 Image based install and upgrade (IBU) support for SSR 6.3.0.

--- a/sidebars.js
+++ b/sidebars.js
@@ -44,7 +44,7 @@ module.exports = {
       "upgrade_ibu_conductor",
       "upgrade_router",
       "upgrade_restricted_access",
-      "upgrade_legacy",  
+      "upgrade_legacy",
       "intro_rollback",
     ],
     "Installation Overview": [
@@ -53,7 +53,7 @@ module.exports = {
     ],
     "SSR Universal ISO Installation": [
       "intro_installation_univ-iso",
-      "install_univ_iso", 
+      "install_univ_iso",
       "initialize_u-iso_device",
       "initialize_u-iso_adv_workflow",
     ],
@@ -127,7 +127,7 @@ module.exports = {
             "legacy_OTP_install",
           ],
       },
-    ],            
+    ],
     "Concepts": [
       "concepts_application_discovery",
       "concepts_EthOverSVR",
@@ -361,7 +361,7 @@ module.exports = {
       "events_alarms",
       "events_events",
       "config_alarm_suppression",
-      "howto_maintenance_mode",      
+      "howto_maintenance_mode",
     ],
     "Best Practices": [
       "bcp_sdwan_design_guide",


### PR DESCRIPTION
## Description
Add release notes for plugin bugfix

* Primary fix is a downgrade issue introduced by IBU
* DNS App ID, Wireguard have a few other bug fixes
* HTTP Probe is getting new feature content (Up Delay Timer) -- https://github.com/128technology/docs/pull/772/commits

## Testing
Verified pages locally