### PR TITLE
Add SCO re-onboarding step to ensure no authorized keys escape cleanup

### DIFF
--- a/docs/sec-conductor-onboard.md
+++ b/docs/sec-conductor-onboard.md
@@ -149,7 +149,27 @@ Mon 2026-08-10 18:29:06 UTC
 
 ```
 
-3. Restore the original asset ID.
+3. Ensure all authorized keys are removed for the original asset ID.
+
+`delete system connectivity authorized-keys entry comment <asset-id> node all`
+
+This operation may indicate keys were removed.
+
+```
+admin@node0.Conductor# delete system connectivity authorized-keys entry comment Spoke1Node0 node all
+✔ Updating SSH Configuration...
+Deleted 2 entries on node0.Conductor
+```
+
+Alternatively, the keys may have been missing or removed by the temporary asset rename. It is **not an issue** if no entries are removed.
+
+```
+admin@node0.Conductor# delete system connectivity authorized-keys entry comment Spoke1Node0 node all
+✔ Updating SSH Configuration...
+Deleted 0 entries on node0.Conductor
+```
+
+4. Restore the original asset ID.
 
     `config authority router <router> node <node> asset-id <asset-id>`
 


### PR DESCRIPTION
There's a particular case where

1. SCO has completed and placed authorized keys
2. Salt onboarding has not been attempted

In this case, the AP does not have any state for the asset. Cleanup does not attempt to remove the authorized keys when the AP hasn't seen that asset. The result is subsequent SCO attempts would repeatedly fail as already complete (which would be correct because authorized keys already exist).

Explicit cleaning prevents this partial onboarding corner case and ensures SCO can be rerun from the beginning.